### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-flow-rawlink.opam
+++ b/mirage-flow-rawlink.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-flow-rawlink/"
 bug-reports: "https://github.com/mirage/mirage-flow-rawlink/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build & >= "1.0"}
+  "dune" {>= "1.0"}
   "mirage-flow-lwt" {>= "1.2.0"}
   "rawlink" {>= "0.5"}
   "cstruct"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.